### PR TITLE
Add NestJS auth microservice skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+MONGO_URI=mongodb://localhost:27017/nest-auth
+JWT_SECRET=changeme
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/apps/nestjs-auth-service/.gitignore
+++ b/apps/nestjs-auth-service/.gitignore
@@ -1,0 +1,56 @@
+# compiled output
+/dist
+/node_modules
+/build
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# temp directory
+.temp
+.tmp
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/apps/nestjs-auth-service/.prettierrc
+++ b/apps/nestjs-auth-service/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/apps/nestjs-auth-service/README.md
+++ b/apps/nestjs-auth-service/README.md
@@ -1,0 +1,98 @@
+<p align="center">
+  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
+</p>
+
+[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
+[circleci-url]: https://circleci.com/gh/nestjs/nest
+
+  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
+    <p align="center">
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
+<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
+<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
+<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
+<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
+  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
+    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
+  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
+</p>
+  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
+  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+
+## Description
+
+[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+
+## Project setup
+
+```bash
+$ npm install
+```
+
+## Compile and run the project
+
+```bash
+# development
+$ npm run start
+
+# watch mode
+$ npm run start:dev
+
+# production mode
+$ npm run start:prod
+```
+
+## Run tests
+
+```bash
+# unit tests
+$ npm run test
+
+# e2e tests
+$ npm run test:e2e
+
+# test coverage
+$ npm run test:cov
+```
+
+## Deployment
+
+When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+
+If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+
+```bash
+$ npm install -g @nestjs/mau
+$ mau deploy
+```
+
+With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+
+## Resources
+
+Check out a few resources that may come in handy when working with NestJS:
+
+- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
+- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
+- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
+- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
+- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
+- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
+- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
+- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
+
+## Support
+
+Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+
+## Stay in touch
+
+- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
+- Website - [https://nestjs.com](https://nestjs.com/)
+- Twitter - [@nestframework](https://twitter.com/nestframework)
+
+## License
+
+Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).

--- a/apps/nestjs-auth-service/eslint.config.mjs
+++ b/apps/nestjs-auth-service/eslint.config.mjs
@@ -1,0 +1,34 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+      sourceType: 'commonjs',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn'
+    },
+  },
+);

--- a/apps/nestjs-auth-service/nest-cli.json
+++ b/apps/nestjs-auth-service/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/apps/nestjs-auth-service/src/app.controller.ts
+++ b/apps/nestjs-auth-service/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/apps/nestjs-auth-service/src/app.module.ts
+++ b/apps/nestjs-auth-service/src/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
+
+@Module({
+  imports: [
+    MongooseModule.forRoot(process.env.MONGO_URI || 'mongodb://localhost/nest'),
+    AuthModule,
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/apps/nestjs-auth-service/src/app.service.ts
+++ b/apps/nestjs-auth-service/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/apps/nestjs-auth-service/src/auth/auth.controller.ts
+++ b/apps/nestjs-auth-service/src/auth/auth.controller.ts
@@ -1,0 +1,64 @@
+import { Body, Controller, Post, Get, Req, Res } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { SignupDto } from './dto/signup.dto';
+import { LoginDto } from './dto/login.dto';
+import { Request, Response } from 'express';
+import { Auth, type AuthConfig } from '@auth/core';
+import GoogleProvider from '@auth/core/providers/google';
+import { MongoDBAdapter } from '@auth/mongodb-adapter';
+import { MongoClient } from 'mongodb';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('signup')
+  async signup(@Body() dto: SignupDto) {
+    const user = await this.authService.register(dto.email, dto.password);
+    const accessToken = await this.authService.generateAccessToken(user.id);
+    const refreshToken = await this.authService.generateRefreshToken(user.id);
+    return { accessToken, refreshToken };
+  }
+
+  @Post('login')
+  async login(@Body() dto: LoginDto) {
+    const user = await this.authService.validateUser(dto.email, dto.password);
+    if (!user) return { error: 'invalid credentials' };
+    const accessToken = await this.authService.generateAccessToken(user.id);
+    const refreshToken = await this.authService.generateRefreshToken(user.id);
+    return { accessToken, refreshToken };
+  }
+
+  @Post('refresh')
+  async refresh(@Body('refreshToken') token: string) {
+    const accessToken = await this.authService.refresh(token);
+    return { accessToken };
+  }
+
+  @Get('google')
+  async google(@Req() req: Request, @Res() res: Response) {
+    const client = new MongoClient(process.env.MONGO_URI || '');
+    await client.connect();
+    const authOptions: AuthConfig = {
+      providers: [
+        GoogleProvider({
+          clientId: process.env.GOOGLE_CLIENT_ID || '',
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+        }),
+      ],
+      session: { strategy: 'jwt' },
+      adapter: MongoDBAdapter(client),
+      secret: process.env.JWT_SECRET,
+    };
+    const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+    const authReq = new globalThis.Request(url, {
+      headers: req.headers as any,
+      method: req.method,
+    });
+    const response = await Auth(authReq, authOptions);
+    res.status(response.status);
+    response.headers.forEach((value, key) => res.setHeader(key, value));
+    const body = await response.text();
+    res.send(body);
+  }
+}

--- a/apps/nestjs-auth-service/src/auth/auth.module.ts
+++ b/apps/nestjs-auth-service/src/auth/auth.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { User, UserSchema } from '../user/user.schema';
+import { RefreshToken, RefreshTokenSchema } from './refresh-token.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: User.name, schema: UserSchema },
+      { name: RefreshToken.name, schema: RefreshTokenSchema },
+    ]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'secret',
+      signOptions: { expiresIn: '1h' },
+    }),
+  ],
+  providers: [AuthService],
+  controllers: [AuthController],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/apps/nestjs-auth-service/src/auth/auth.service.ts
+++ b/apps/nestjs-auth-service/src/auth/auth.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
+import { User } from '../user/user.schema';
+import { RefreshToken } from './refresh-token.schema';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectModel(User.name) private userModel: Model<User>,
+    @InjectModel(RefreshToken.name) private tokenModel: Model<RefreshToken>,
+    private jwtService: JwtService,
+  ) {}
+
+  async hashPassword(password: string): Promise<string> {
+    return bcrypt.hash(password, 10);
+  }
+
+  async validateUser(email: string, password: string): Promise<User | null> {
+    const user = await this.userModel.findOne({ email }).exec();
+    if (!user || !user.password) return null;
+    const valid = await bcrypt.compare(password, user.password);
+    return valid ? user : null;
+  }
+
+  async register(email: string, password: string): Promise<User> {
+    const hashed = await this.hashPassword(password);
+    const user = new this.userModel({ email, password: hashed });
+    return user.save();
+  }
+
+  async generateAccessToken(userId: string): Promise<string> {
+    return this.jwtService.sign({ sub: userId });
+  }
+
+  async generateRefreshToken(userId: string): Promise<string> {
+    const token = this.jwtService.sign(
+      { sub: userId },
+      { expiresIn: '7d', secret: process.env.JWT_SECRET || 'secret' },
+    );
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    await this.tokenModel.create({ userId, token, expiresAt });
+    return token;
+  }
+
+  async refresh(token: string): Promise<string | null> {
+    const stored = await this.tokenModel.findOne({ token }).exec();
+    if (!stored) return null;
+    if (stored.expiresAt < new Date()) return null;
+    const payload = this.jwtService.verify(token, {
+      secret: process.env.JWT_SECRET || 'secret',
+    });
+    return this.generateAccessToken(payload.sub);
+  }
+}

--- a/apps/nestjs-auth-service/src/auth/dto/login.dto.ts
+++ b/apps/nestjs-auth-service/src/auth/dto/login.dto.ts
@@ -1,0 +1,4 @@
+export class LoginDto {
+  email: string;
+  password: string;
+}

--- a/apps/nestjs-auth-service/src/auth/dto/signup.dto.ts
+++ b/apps/nestjs-auth-service/src/auth/dto/signup.dto.ts
@@ -1,0 +1,4 @@
+export class SignupDto {
+  email: string;
+  password: string;
+}

--- a/apps/nestjs-auth-service/src/auth/refresh-token.schema.ts
+++ b/apps/nestjs-auth-service/src/auth/refresh-token.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class RefreshToken extends Document {
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ required: true })
+  token: string;
+
+  @Prop({ required: true })
+  expiresAt: Date;
+}
+
+export const RefreshTokenSchema = SchemaFactory.createForClass(RefreshToken);

--- a/apps/nestjs-auth-service/src/main.ts
+++ b/apps/nestjs-auth-service/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 3000);
+}
+bootstrap();

--- a/apps/nestjs-auth-service/src/user/user.module.ts
+++ b/apps/nestjs-auth-service/src/user/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { User, UserSchema } from './user.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  exports: [MongooseModule],
+})
+export class UserModule {}

--- a/apps/nestjs-auth-service/src/user/user.schema.ts
+++ b/apps/nestjs-auth-service/src/user/user.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class User extends Document {
+  @Prop({ required: true, unique: true })
+  email: string;
+
+  @Prop()
+  password?: string;
+
+  @Prop()
+  googleId?: string;
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);

--- a/apps/nestjs-auth-service/tsconfig.app.json
+++ b/apps/nestjs-auth-service/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/nestjs-auth-service"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/apps/nestjs-auth-service/tsconfig.build.json
+++ b/apps/nestjs-auth-service/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/apps/nestjs-auth-service/tsconfig.json
+++ b/apps/nestjs-auth-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2023",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,20 @@
+{
+  "monorepo": true,
+  "root": "apps/nestjs-auth-service",
+  "sourceRoot": "apps/nestjs-auth-service/src",
+  "compilerOptions": {
+    "webpack": true,
+    "tsConfigPath": "apps/nestjs-auth-service/tsconfig.app.json"
+  },
+  "projects": {
+    "nestjs-auth-service": {
+      "type": "application",
+      "root": "apps/nestjs-auth-service",
+      "entryFile": "main",
+      "sourceRoot": "apps/nestjs-auth-service/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/nestjs-auth-service/tsconfig.app.json"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "nestjs-auth-service",
+  "version": "1.0.0",
+  "description": "NestJS authentication microservice",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "nest start --watch",
+    "build": "tsc -p apps/nestjs-auth-service/tsconfig.build.json"
+  },
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "@auth/core": "^0.40.0",
+    "@auth/mongodb-adapter": "^3.10.0",
+    "@nestjs/common": "^11.1.5",
+    "@nestjs/core": "^11.1.5",
+    "@nestjs/platform-express": "^11.1.5",
+    "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mongoose": "^11.0.3",
+    "@nestjs/passport": "^11.0.5",
+    "bcrypt": "^6.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.16.5",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^11.0.8",
+    "typescript": "^5.4.5"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a NestJS auth service with MongoDB
- add JWT-based auth with refresh tokens
- integrate Google login through Auth.js
- provide example environment variables

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_688895caae1083218416488a1db48021